### PR TITLE
Support for symbols in hash passed to expand.

### DIFF
--- a/lib/uri_template.rb
+++ b/lib/uri_template.rb
@@ -221,11 +221,19 @@ module URITemplate
 
   # Expands this uri template with the given variables.
   # The variables should be converted to strings using {Utils#object_to_param}.
+  #
+  # The keys in the variables hash are converted to
+  # strings in order to support the Ruby 1.9 hash syntax.
+  #
   # @raise {Unconvertable} if a variable could not be converted to a string.
   # @param variables Hash
   # @return String
   def expand(variables = {})
     raise ArgumentError, "Expected something that returns to :[], but got: #{variables.inspect}" unless variables.respond_to? :[]
+
+    # Stringify variables
+    variables = Hash[variables.map{ |k, v| [k.to_s, v] }]
+
     tokens.map{|part|
       part.expand(variables)
     }.join

--- a/spec/uri_template_spec.rb
+++ b/spec/uri_template_spec.rb
@@ -118,6 +118,22 @@ describe URITemplate do
 
   end
 
+  describe "expand" do
+    it 'should expand variables from a hash where the keys are symbols' do
+      t = URITemplate.new("/foo{?bar}")
+      v = { :bar => 'qux' }
+
+      t.expand(v).should == '/foo?bar=qux'
+    end
+
+    it 'should expand variables from a hash with mixed key types' do
+      t = URITemplate.new("{/list*}/{?bar}")
+      v = { :bar => 'qux', "list" => ['a', :b] }
+
+      t.expand(v).should == '/a/b/?bar=qux'
+    end
+  end
+
   describe "docs" do
 
     gem 'yard'


### PR DESCRIPTION
All keys in the variables hash are converted to strings. (Quite similar to [Hash#stringify_keys!](http://apidock.com/rails/Hash/stringify_keys%21) in Rails)

I decided against checking for the key class, but it would be trivial to check `k.is_a?(Symbol)` if we need to support anything else than `Symbol` and `String` keys.
### Ruby 1.9

Ruby 1.9 hashes are ordered, which means that the last key in a collision is used in the template expansion.
### Ruby 1.8

The behavior under Ruby 1.8 is undefined, but it seems like symbols take precedence over strings.
### Tests

I’ve tested the code using `ree-2012.02` and `1.9.3p125`, all green :ok_hand:
