### PR TITLE
Array-based expansion of template variables

### DIFF
--- a/lib/uri_template.rb
+++ b/lib/uri_template.rb
@@ -192,13 +192,19 @@ RUBY
   # The keys in the variables hash are converted to
   # strings in order to support the Ruby 1.9 hash syntax.
   #
+  # If the variables are given as an array, they will be matched against the variables in the template based on their order.
+  #
   # @raise {Unconvertable} if a variable could not be converted to a string.
   # @raise {InvalidValue} if a value is not suiteable for a certain variable ( e.g. a string when a list is expected ).
   #
-  # @param variables [#map]
+  # @param variables [#map, Array]
   # @return String
   def expand(variables = {})
     raise ArgumentError, "Expected something that responds to :map, but got: #{variables.inspect}" unless variables.respond_to? :map
+
+    if variables.kind_of?(Array)
+      variables = Hash[self.variables.uniq.zip(variables)]
+    end
 
     # Stringify variables
     arg = variables.map{ |k, v| [k.to_s, v] }

--- a/spec/colon_spec.rb
+++ b/spec/colon_spec.rb
@@ -148,6 +148,12 @@ describe URITemplate::Colon do
       tpl = URITemplate.new(:colon, '/*/*.*')
 
       tpl.should expand('splat' => ['dir','b/c','ext'] ).to('/dir/b/c.ext')
+    end
+
+    it 'should support splats using array expansion' do
+
+      tpl = URITemplate.new(:colon, '/*/*.*')
+      tpl.should expand([['dir','b/c','ext']] ).to('/dir/b/c.ext')
 
     end
 

--- a/spec/rfc6570_spec.rb
+++ b/spec/rfc6570_spec.rb
@@ -123,6 +123,13 @@ describe URITemplate::RFC6570 do
 
     end
 
+    it 'should expand assocs when using array expansion' do
+
+      t = URITemplate::RFC6570.new("{?assoc*}")
+      t.should expand([{'.'=>'dot'}]).to('?.=dot')
+
+    end
+
     it 'should expand empty arrays' do
       t = URITemplate::RFC6570.new("{arr}")
       t.should expand('arr' => []).to("")

--- a/spec/uri_template_spec.rb
+++ b/spec/uri_template_spec.rb
@@ -178,6 +178,11 @@ describe URITemplate do
 
       t.expand(v).should == '/a/b/?bar=qux'
     end
+
+    it 'should expand variables from an array' do
+      t = URITemplate.new("/{foo}{/list*}/{?bar}")
+      t.should expand(['bar', ['a', :b], 'qux']).to '/bar/a/b/?bar=qux'
+    end
   end
 
   describe "docs" do


### PR DESCRIPTION
Allows expanding templates without specifying the keys:

```
URITemplate.new('/{foo}/{bar}').expand(['1, '2'])
# => '/1/2'
```
