### PR TITLE
Add license file that ships with the Gem

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2011-2020 Hannes Voigt-Georg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # URITemplate - a uri template library
 
-[![Build Status](https://secure.travis-ci.org/hannesg/uri_template.png)](http://travis-ci.org/hannesg/uri_template)
-[![Dependency Status](https://gemnasium.com/hannesg/uri_template.png)](https://gemnasium.com/hannesg/uri_template)
-[![Code Climate](https://codeclimate.com/github/hannesg/uri_template.png)](https://codeclimate.com/github/hannesg/uri_template)
-[![Coverage](https://coveralls.io/repos/hannesg/uri_template/badge.png?branch=master)](https://coveralls.io/r/hannesg/uri_template)
+[![Build Status](https://secure.travis-ci.org/hannesg/uri_template.svg)](http://travis-ci.org/hannesg/uri_template)
+[![Code Climate](https://codeclimate.com/github/hannesg/uri_template.svg)](https://codeclimate.com/github/hannesg/uri_template)
+[![Coverage](https://coveralls.io/repos/hannesg/uri_template/badge.svg?branch=master)](https://coveralls.io/r/hannesg/uri_template)
 
-With URITemplate you can generate URIs based on simple templates and extract variables from URIs using the same templates. There are currently two syntaxes defined. Namely the one defined in [RFC 6570]( http://tools.ietf.org/html/rfc6570 ) and a colon based syntax, similiar to the one used by sinatra.
+With URITemplate you can generate URIs based on simple templates and extract variables from URIs using the same templates. There are currently two syntaxes defined. Namely, the one defined in [RFC 6570]( http://tools.ietf.org/html/rfc6570 ) and a colon based syntax, similar to the one used by sinatra.
 
 From version 0.2.0, it will use escape_utils if available. This will significantly boost uri-escape/unescape performance if more characters need to be escaped ( may be slightly slower in trivial cases. working on that ... ), but does not run everywhere. To enable this, do the following:
 

--- a/uri_template.gemspec
+++ b/uri_template.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.files = Dir.glob('lib/**/**/*.rb') + ['uri_template.gemspec', 'README.md', 'CHANGELOG.md']
+  s.files = Dir.glob('lib/**/**/*.rb') + ['uri_template.gemspec', 'README.md', 'CHANGELOG.md', 'LICENSE']
 
   s.add_development_dependency 'multi_json'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
A lot of people run license scanners in their projects to ensure they're
compliant with corporate license policies. I added a license file that
ships with the gem to help those folks out. I also fixed the readme
badges and some readme typos while I was in there. I'd greatly
appreciate a merge / release of this.

Signed-off-by: Tim Smith <tsmith@chef.io>